### PR TITLE
feat: matchingListPage 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
+    "@mui/icons-material": "^6.1.2",
+    "@mui/material": "^6.1.2",
     "normalize.css": "^8.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@emotion/styled':
         specifier: ^11.13.0
         version: 11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
+      '@mui/icons-material':
+        specifier: ^6.1.2
+        version: 6.1.2(@mui/material@6.1.2(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
+      '@mui/material':
+        specifier: ^6.1.2
+        version: 6.1.2(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       normalize.css:
         specifier: ^8.0.1
         version: 8.0.1
@@ -364,6 +370,97 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
+  '@mui/core-downloads-tracker@6.1.2':
+    resolution: {integrity: sha512-1oE4U38/TtzLWRYWEm/m70dUbpcvBx0QvDVg6NtpOmSNQC1Mbx0X/rNvYDdZnn8DIsAiVQ+SZ3am6doSswUQ4g==}
+
+  '@mui/icons-material@6.1.2':
+    resolution: {integrity: sha512-7NNcjW5JoT9jHagrVbARA1o41vQY2xezDamtke+mEKKZmsJyejfRBOacSrPDfjZQ//lyhIjNKyzAwisxYJR47w==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@mui/material': ^6.1.2
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/material@6.1.2':
+    resolution: {integrity: sha512-5TtHeAVX9D5d2LYfB1GAUn29BcVETVsrQ76Dwb2SpAfQGW3JVy4deJCAd0RrIkI3eEUrsl0E4xuBdreszxdTTg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@mui/material-pigment-css': ^6.1.2
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@mui/material-pigment-css':
+        optional: true
+      '@types/react':
+        optional: true
+
+  '@mui/private-theming@6.1.2':
+    resolution: {integrity: sha512-S8WcjZdNdi++8UhrrY8Lton5h/suRiQexvdTfdcPAlbajlvgM+kx+uJstuVIEyTb3gMkxzIZep87knZ0tqcR0g==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/styled-engine@6.1.2':
+    resolution: {integrity: sha512-uKOfWkR23X39xj7th2nyTcCHqInTAXtUnqD3T5qRVdJcOPvu1rlgTleTwJC/FJvWZJBU6ieuTWDhbcx5SNViHQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.4.1
+      '@emotion/styled': ^11.3.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
+  '@mui/system@6.1.2':
+    resolution: {integrity: sha512-mzW7F1ZMIYS1aLON48Nrk9c65OrVEVQ+R4lUcTWs1lCSul0VGK23eo4dmY0NX5PS7Oe4xz3P5B9tQZZ7SYgxcg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
+
+  '@mui/types@7.2.17':
+    resolution: {integrity: sha512-oyumoJgB6jDV8JFzRqjBo2daUuHpzDjoO/e3IrRhhHo/FxJlaVhET6mcNrKHUq2E+R+q3ql0qAtvQ4rfWHhAeQ==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/utils@6.1.2':
+    resolution: {integrity: sha512-6+B1YZ8cCBWD1fc3RjqpclF9UA0MLUiuXhyCO+XowD/Z2ku5IlxeEhHHlgglyBWFGMu4kib4YU3CDsG5/zVjJQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -375,6 +472,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@popperjs/core@2.11.8':
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
   '@rollup/rollup-android-arm-eabi@4.24.0':
     resolution: {integrity: sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==}
@@ -548,6 +648,9 @@ packages:
 
   '@types/react-dom@18.3.0':
     resolution: {integrity: sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==}
+
+  '@types/react-transition-group@4.4.11':
+    resolution: {integrity: sha512-RM05tAniPZ5DZPzzNFP+DmrcOdD0efDUxMy3145oljWSl3x9ZV5vhme98gTxFrj2lhXvmGNnUiuDyJgY9IKkNA==}
 
   '@types/react@18.3.11':
     resolution: {integrity: sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==}
@@ -728,6 +831,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
 
@@ -815,6 +922,9 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
@@ -1463,6 +1573,15 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -1996,6 +2115,90 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@mui/core-downloads-tracker@6.1.2': {}
+
+  '@mui/icons-material@6.1.2(@mui/material@6.1.2(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@mui/material': 6.1.2(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@mui/material@6.1.2(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@mui/core-downloads-tracker': 6.1.2
+      '@mui/system': 6.1.2(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
+      '@mui/types': 7.2.17(@types/react@18.3.11)
+      '@mui/utils': 6.1.2(@types/react@18.3.11)(react@18.3.1)
+      '@popperjs/core': 2.11.8
+      '@types/react-transition-group': 4.4.11
+      clsx: 2.1.1
+      csstype: 3.1.3
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    optionalDependencies:
+      '@emotion/react': 11.13.3(@types/react@18.3.11)(react@18.3.1)
+      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
+      '@types/react': 18.3.11
+
+  '@mui/private-theming@6.1.2(@types/react@18.3.11)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@mui/utils': 6.1.2(@types/react@18.3.11)(react@18.3.1)
+      prop-types: 15.8.1
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@mui/styled-engine@6.1.2(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@emotion/cache': 11.13.1
+      '@emotion/sheet': 1.4.0
+      csstype: 3.1.3
+      prop-types: 15.8.1
+      react: 18.3.1
+    optionalDependencies:
+      '@emotion/react': 11.13.3(@types/react@18.3.11)(react@18.3.1)
+      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
+
+  '@mui/system@6.1.2(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@mui/private-theming': 6.1.2(@types/react@18.3.11)(react@18.3.1)
+      '@mui/styled-engine': 6.1.2(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1))(react@18.3.1)
+      '@mui/types': 7.2.17(@types/react@18.3.11)
+      '@mui/utils': 6.1.2(@types/react@18.3.11)(react@18.3.1)
+      clsx: 2.1.1
+      csstype: 3.1.3
+      prop-types: 15.8.1
+      react: 18.3.1
+    optionalDependencies:
+      '@emotion/react': 11.13.3(@types/react@18.3.11)(react@18.3.1)
+      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.11)(react@18.3.1))(@types/react@18.3.11)(react@18.3.1)
+      '@types/react': 18.3.11
+
+  '@mui/types@7.2.17(@types/react@18.3.11)':
+    optionalDependencies:
+      '@types/react': 18.3.11
+
+  '@mui/utils@6.1.2(@types/react@18.3.11)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.7
+      '@mui/types': 7.2.17(@types/react@18.3.11)
+      '@types/prop-types': 15.7.13
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-is: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.11
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2007,6 +2210,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+
+  '@popperjs/core@2.11.8': {}
 
   '@rollup/rollup-android-arm-eabi@4.24.0':
     optional: true
@@ -2119,6 +2324,10 @@ snapshots:
   '@types/prop-types@15.7.13': {}
 
   '@types/react-dom@18.3.0':
+    dependencies:
+      '@types/react': 18.3.11
+
+  '@types/react-transition-group@4.4.11':
     dependencies:
       '@types/react': 18.3.11
 
@@ -2363,6 +2572,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  clsx@2.1.1: {}
+
   color-convert@1.9.3:
     dependencies:
       color-name: 1.1.3
@@ -2467,6 +2678,11 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.25.7
+      csstype: 3.1.3
 
   emoji-regex@9.2.2: {}
 
@@ -3258,6 +3474,17 @@ snapshots:
       scheduler: 0.23.2
 
   react-is@16.13.1: {}
+
+  react-is@18.3.1: {}
+
+  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.25.7
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react@18.3.1:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
 import './App.css';
-import LoginPage from './pages/LoginPage.tsx';
+import MatchingListPage from './pages/MatchingListPage.tsx';
 
 function App() {
   return (
     <>
-      <LoginPage />
+      {/* <LoginPage /> */}
+      <MatchingListPage />
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import './App.css';
+// import LoginPage from './pages/LoginPage.tsx';
 import MatchingListPage from './pages/MatchingListPage.tsx';
 
 function App() {

--- a/src/components/FooterTabButton.tsx
+++ b/src/components/FooterTabButton.tsx
@@ -17,7 +17,12 @@ const SubText = styled.p`
   font-weight: 400;
 `;
 
-const MatchingListButton = ({ type, text }) => {
+interface FooterTabButtonProps {
+  type: string;
+  text: string;
+}
+
+const FooterTabButton = ({ type, text }: FooterTabButtonProps) => {
   return (
     <ButtonBox>
       {type === 'list' ? (
@@ -30,4 +35,4 @@ const MatchingListButton = ({ type, text }) => {
   );
 };
 
-export default MatchingListButton;
+export default FooterTabButton;

--- a/src/components/MatchingButton.tsx
+++ b/src/components/MatchingButton.tsx
@@ -5,6 +5,7 @@ const CircleButton = styled.button`
   padding: 0.45rem;
   border-radius: 50%;
   border: 1px solid black;
+  cursor: pointer;
 `;
 
 const SubText = styled.p`

--- a/src/components/MatchingButton.tsx
+++ b/src/components/MatchingButton.tsx
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+
+const CircleButton = styled.button`
+  height: 2.25rem;
+  padding: 0.45rem;
+  border-radius: 50%;
+  border: 1px solid black;
+`;
+
+const SubText = styled.p`
+  font-size: 0.75rem;
+  font-weight: 400;
+  margin: 0;
+`;
+
+const MatchingButton = () => {
+  return (
+    <CircleButton>
+      <SubText>매칭</SubText>
+    </CircleButton>
+  );
+};
+
+export default MatchingButton;

--- a/src/components/MatchingListButton.tsx
+++ b/src/components/MatchingListButton.tsx
@@ -1,0 +1,33 @@
+import styled from '@emotion/styled';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
+
+const ButtonBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 50%;
+  border: 1px solid black;
+  cursor: pointer;
+`;
+
+const SubText = styled.p`
+  font-size: 1rem;
+  font-weight: 400;
+`;
+
+const MatchingListButton = ({ type, text }) => {
+  return (
+    <ButtonBox>
+      {type === 'list' ? (
+        <FormatListBulletedIcon fontSize='large' />
+      ) : (
+        <ChatBubbleOutlineIcon fontSize='large' />
+      )}
+      <SubText>{text}</SubText>
+    </ButtonBox>
+  );
+};
+
+export default MatchingListButton;

--- a/src/components/MatchingUser.tsx
+++ b/src/components/MatchingUser.tsx
@@ -1,0 +1,30 @@
+import styled from '@emotion/styled';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+import MatchingButton from './MatchingButton.tsx';
+
+const UserBox = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 2.25rem;
+  /* border: 1px solid black; */
+`;
+
+const SubText = styled.p`
+  font-size: 1rem;
+  font-weight: 400;
+  margin: 0;
+  flex-grow: 1;
+`;
+
+const MatchingUser = () => {
+  return (
+    <UserBox>
+      <AccountCircleIcon fontSize='large' />
+      <SubText>사용자 ID</SubText>
+      <MatchingButton />
+    </UserBox>
+  );
+};
+
+export default MatchingUser;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -9,6 +9,8 @@ const Container = styled.div`
   flex-direction: column;
   height: 100vh;
   width: 100%;
+  max-width: 30rem;
+  margin: 0 auto;
 `;
 
 const Box = styled.div`

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -55,16 +55,16 @@ const LoginPage = () => {
       <Box>
         <InputBox>
           <SubText>Id</SubText>
-          <TextInput placeholder={'아이디를 입력하세요'} />
+          <TextInput placeholder='아이디를 입력하세요' />
         </InputBox>
 
         <InputBox>
           <SubText>Password</SubText>
-          <TextInput placeholder={'비밀번호를 입력하세요'} />
+          <TextInput placeholder='비밀번호를 입력하세요' />
         </InputBox>
 
         <ButtonBox>
-          <DefaultButton text={'Sign In'} />
+          <DefaultButton text='Sign In' />
         </ButtonBox>
       </Box>
     </Container>

--- a/src/pages/MatchingListPage.tsx
+++ b/src/pages/MatchingListPage.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import MatchingUser from '../components/MatchingUser.tsx';
-import MatchingListButton from '../components/MatchingListButton.tsx';
+import FooterTabButton from '../components/FooterTabButton.tsx';
 
 const Container = styled.div`
   display: flex;
@@ -78,8 +78,8 @@ const MatchingListPage = () => {
         {/* </UserBox> */}
       </Box>
       <ButtonBox>
-        <MatchingListButton text={'매칭 대기 목록'} type={'list'} />
-        <MatchingListButton text={'채팅창'} type={'chat'} />
+        <FooterTabButton text={'매칭 대기 목록'} type={'list'} />
+        <FooterTabButton text={'채팅창'} type={'chat'} />
       </ButtonBox>
     </Container>
   );

--- a/src/pages/MatchingListPage.tsx
+++ b/src/pages/MatchingListPage.tsx
@@ -1,0 +1,82 @@
+import styled from '@emotion/styled';
+import MatchingUser from '../components/MatchingUser.tsx';
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  height: 100vh;
+  width: 100%;
+  position: relative;
+`;
+
+const TextBox = styled.div`
+  display: flex;
+  width: 80%;
+  align-items: flex-start;
+`;
+
+const MainText = styled.h1`
+  font-size: 1.25rem;
+  font-weight: 500;
+  margin: 0;
+  margin-bottom: 1.5rem;
+`;
+
+const Box = styled.div`
+  width: 80%;
+  height: 70%;
+  display: flex;
+  overflow-y: auto;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+const ButtonBox = styled.div`
+  width: 100%;
+  height: 4.5rem;
+  background-color: rgb(243, 237, 247, 100);
+  position: absolute;
+  bottom: 0;
+  display: flex;
+`;
+
+const MatchingListPage = () => {
+  return (
+    <Container>
+      <TextBox>
+        <MainText>매칭 대기 목록</MainText>
+      </TextBox>
+      <Box>
+        {/* <UserBox> */}
+        <MatchingUser />
+        <MatchingUser />
+        <MatchingUser />
+        <MatchingUser />
+        <MatchingUser />
+        <MatchingUser />
+        <MatchingUser />
+        <MatchingUser />
+        <MatchingUser />
+        <MatchingUser />
+        <MatchingUser />
+        <MatchingUser />
+        <MatchingUser />
+        <MatchingUser />
+        <MatchingUser />
+        <MatchingUser />
+        <MatchingUser />
+        {/* </UserBox> */}
+      </Box>
+      <ButtonBox></ButtonBox>
+    </Container>
+  );
+};
+
+export default MatchingListPage;

--- a/src/pages/MatchingListPage.tsx
+++ b/src/pages/MatchingListPage.tsx
@@ -78,8 +78,8 @@ const MatchingListPage = () => {
         {/* </UserBox> */}
       </Box>
       <ButtonBox>
-        <FooterTabButton text={'매칭 대기 목록'} type={'list'} />
-        <FooterTabButton text={'채팅창'} type={'chat'} />
+        <FooterTabButton text='매칭 대기 목록' type='list' />
+        <FooterTabButton text='채팅창' type='chat' />
       </ButtonBox>
     </Container>
   );

--- a/src/pages/MatchingListPage.tsx
+++ b/src/pages/MatchingListPage.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import MatchingUser from '../components/MatchingUser.tsx';
+import MatchingListButton from '../components/MatchingListButton.tsx';
 
 const Container = styled.div`
   display: flex;
@@ -8,6 +9,8 @@ const Container = styled.div`
   flex-direction: column;
   height: 100vh;
   width: 100%;
+  max-width: 30rem;
+  margin: 0 auto;
   position: relative;
 `;
 
@@ -74,7 +77,10 @@ const MatchingListPage = () => {
         <MatchingUser />
         {/* </UserBox> */}
       </Box>
-      <ButtonBox></ButtonBox>
+      <ButtonBox>
+        <MatchingListButton text={'매칭 대기 목록'} type={'list'} />
+        <MatchingListButton text={'채팅창'} type={'chat'} />
+      </ButtonBox>
     </Container>
   );
 };

--- a/src/pages/MatchingListPage.tsx
+++ b/src/pages/MatchingListPage.tsx
@@ -8,10 +8,11 @@ const Container = styled.div`
   justify-content: center;
   flex-direction: column;
   height: 100vh;
-  width: 100%;
-  max-width: 30rem;
+  max-height: 932px;
+  max-width: 480px;
   margin: 0 auto;
   position: relative;
+  border: 1px solid black;
 `;
 
 const TextBox = styled.div`
@@ -28,13 +29,16 @@ const MainText = styled.h1`
 `;
 
 const Box = styled.div`
-  width: 80%;
+  box-sizing: border-box;
+  width: 100%;
+  padding: 0 10%;
   height: 70%;
   display: flex;
   overflow-y: auto;
   flex-direction: column;
   align-items: flex-start;
   gap: 0.25rem;
+  border: 1px solid black;
 
   &::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
## 관련 이슈
#2 

## 구현한 내용
### 설명
- 매칭 대기 목록 페이지를 구현하였습니다.
  - 피그마를 참고하였습니다.
### 사진 
![image](https://github.com/user-attachments/assets/55fc6c11-a005-4435-ba8b-b13aa0dec711)
## 리뷰어에게...
### CSS관련
- 최대한 저번주 PR에서 받은 리뷰를 반영하여 작성하였습니다.
  - (반응형 라이브러리를 사용하는게 아닌 아예 모바일 개발이라 또 새롭네요.)
### 컴포넌트 관련

- 현재 FooterTabButton이 존재합니다.
- 해당 버튼은 MatchingListPage에서 가장 하단에 위치하며, 클릭시 매칭 대기 목록, 채팅창을 번갈아 보여줍니다.

```tsx
<FooterTabButton text={'매칭 대기 목록'} type={'list'} />
<FooterTabButton text={'채팅창'} type={'chat'} />
```

- 위와 같은 형식으로 props를 전달해 주고 있는데, 추후에는 여기서 호출해야 할 api가 있습니다.
    - 매칭 대기 목록 api
    - 채팅 목록 api
- 제가 생각하는 올바른 컴포넌트 설계는 하나의 컴포넌트에 ‘하나의 책임’을 가지고 있어야 하는 것입니다.
하지만 현재 컴포넌트에 따르면 MatchingListPage에서 두 개의 custom hook을 나중에 호출해야 하는 일이 발생하게 됩니다.
    - onclick 등을 통해서 custom hook을 props로 내려보내 주게 될 것 같습니다.

### 여기서 발생하는 딜레마

- 현재 구조에서 같은 컴포넌트를 재사용하면서 다른 API를 호출해야 합니다.
- 이러한 경우에는 단일 책임 원칙을 어기게 되는 상황이 발생합니다.

**[동일한 컴포넌트를 재사용하되 props로 custom hook 전달하기]**

- `FooterTabButton`을 재사용하면서 클릭 시 호출할 함수를 props로 전달하는 방식
    - 이게 `MatchingListPage`의 관점에서 custom hook이 추후에 2개가 호출된다면, 단일 책임 원칙에 위배되는 것 같다고 생각됩니다.
- 그런데 또, 다른 생각으로는 `FooterTabButton`은 버튼을 렌더링합니다.
    - `onClick`으로 custom hook을 props로 넘겨줍니다.
    - 이러면 결국 버튼은 단일한 역할(이벤트 처리, 보여주는 역할)을 하게 됩니다.

```tsx
<FooterTabButton 
    text={'매칭 대기 목록'} 
    type={'list'} 
    onClick={fetchMatchingList}
/>
<FooterTabButton 
    text={'채팅창'} 
    type={'chat'} 
    onClick={fetchChatList}
/>
```

- 이러한 경우에는 이런 방식으로 진행을 하는게 나을지 아니면,
- 동일하게 생긴 ui의 버튼임에도, 따로 만들어줘서 아예 ui, hook 전부를 분리해주는 것이 나을지 고민입니다.