### PR TITLE
feat: 컴포넌트 설계 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "@mui/material": "^6.1.2",
     "normalize.css": "^8.0.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.27.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-router-dom:
+        specifier: ^6.27.0
+        version: 6.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@types/react':
         specifier: ^18.3.10
@@ -475,6 +478,10 @@ packages:
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
+  '@remix-run/router@1.20.0':
+    resolution: {integrity: sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==}
+    engines: {node: '>=14.0.0'}
 
   '@rollup/rollup-android-arm-eabi@4.24.0':
     resolution: {integrity: sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==}
@@ -1576,6 +1583,19 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-router-dom@6.27.0:
+    resolution: {integrity: sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  react-router@6.27.0:
+    resolution: {integrity: sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
@@ -2212,6 +2232,8 @@ snapshots:
       fastq: 1.17.1
 
   '@popperjs/core@2.11.8': {}
+
+  '@remix-run/router@1.20.0': {}
 
   '@rollup/rollup-android-arm-eabi@4.24.0':
     optional: true
@@ -3476,6 +3498,18 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@18.3.1: {}
+
+  react-router-dom@6.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@remix-run/router': 1.20.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-router: 6.27.0(react@18.3.1)
+
+  react-router@6.27.0(react@18.3.1):
+    dependencies:
+      '@remix-run/router': 1.20.0
+      react: 18.3.1
 
   react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,23 @@
 import './App.css';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 // import LoginPage from './pages/LoginPage.tsx';
 import MatchingListPage from './pages/MatchingListPage.tsx';
+import LoginPage from './pages/LoginPage.tsx';
+import ChattingPage from './pages/ChattingPage.tsx';
 
 function App() {
   return (
     <>
+      <BrowserRouter>
+        <Routes>
+          <Route path='/matching' element={<MatchingListPage />} />
+          <Route path='/login' element={<LoginPage />} />
+          <Route path='/chat' element={<ChattingPage />} />
+        </Routes>
+      </BrowserRouter>
+
       {/* <LoginPage /> */}
-      <MatchingListPage />
+      {/* <MatchingListPage /> */}
     </>
   );
 }

--- a/src/components/FooterTabButton.tsx
+++ b/src/components/FooterTabButton.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const ButtonBox = styled.div`
   display: flex;
@@ -19,11 +20,18 @@ const SubText = styled.p`
 interface FooterTabButtonProps {
   Icon: React.ElementType;
   text: string;
+  url: string;
 }
 
-const FooterTabButton = ({ text, Icon }: FooterTabButtonProps) => {
+const FooterTabButton = ({ text, Icon, url }: FooterTabButtonProps) => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(`/${url}`);
+  };
+
   return (
-    <ButtonBox>
+    <ButtonBox onClick={handleClick}>
       <Icon fontSize='large' />
       <SubText>{text}</SubText>
     </ButtonBox>

--- a/src/components/FooterTabButton.tsx
+++ b/src/components/FooterTabButton.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 
-const ButtonBox = styled.div`
+const ButtonBox = styled(NavLink)`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -10,6 +10,7 @@ const ButtonBox = styled.div`
   width: 50%;
   border: 1px solid black;
   cursor: pointer;
+  text-decoration: none;
 `;
 
 const SubText = styled.p`
@@ -24,14 +25,8 @@ interface FooterTabButtonProps {
 }
 
 const FooterTabButton = ({ text, Icon, url }: FooterTabButtonProps) => {
-  const navigate = useNavigate();
-
-  const handleClick = () => {
-    navigate(`/${url}`);
-  };
-
   return (
-    <ButtonBox onClick={handleClick}>
+    <ButtonBox to={`/${url}`}>
       <Icon fontSize='large' />
       <SubText>{text}</SubText>
     </ButtonBox>

--- a/src/components/FooterTabButton.tsx
+++ b/src/components/FooterTabButton.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
-import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
-import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
+import React from 'react';
 
 const ButtonBox = styled.div`
   display: flex;
@@ -18,18 +17,14 @@ const SubText = styled.p`
 `;
 
 interface FooterTabButtonProps {
-  type: string;
+  Icon: React.ElementType;
   text: string;
 }
 
-const FooterTabButton = ({ type, text }: FooterTabButtonProps) => {
+const FooterTabButton = ({ text, Icon }: FooterTabButtonProps) => {
   return (
     <ButtonBox>
-      {type === 'list' ? (
-        <FormatListBulletedIcon fontSize='large' />
-      ) : (
-        <ChatBubbleOutlineIcon fontSize='large' />
-      )}
+      <Icon fontSize='large' />
       <SubText>{text}</SubText>
     </ButtonBox>
   );

--- a/src/pages/ChattingPage.tsx
+++ b/src/pages/ChattingPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ChattingPage = () => {
+  return <div>ChattingPage</div>;
+};
+
+export default ChattingPage;

--- a/src/pages/MatchingListPage.tsx
+++ b/src/pages/MatchingListPage.tsx
@@ -84,8 +84,16 @@ const MatchingListPage = () => {
         {/* </UserBox> */}
       </Box>
       <ButtonBox>
-        <FooterTabButton text='매칭 대기 목록' Icon={FormatListBulletedIcon} />
-        <FooterTabButton text='채팅창' Icon={ChatBubbleOutlineIcon} />
+        <FooterTabButton
+          text='매칭 대기 목록'
+          Icon={FormatListBulletedIcon}
+          url='matching'
+        />
+        <FooterTabButton
+          text='채팅창'
+          Icon={ChatBubbleOutlineIcon}
+          url='chat'
+        />
       </ButtonBox>
     </Container>
   );

--- a/src/pages/MatchingListPage.tsx
+++ b/src/pages/MatchingListPage.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
 import MatchingUser from '../components/MatchingUser.tsx';
 import FooterTabButton from '../components/FooterTabButton.tsx';
+import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 
 const Container = styled.div`
   display: flex;
@@ -82,8 +84,8 @@ const MatchingListPage = () => {
         {/* </UserBox> */}
       </Box>
       <ButtonBox>
-        <FooterTabButton text='매칭 대기 목록' type='list' />
-        <FooterTabButton text='채팅창' type='chat' />
+        <FooterTabButton text='매칭 대기 목록' Icon={FormatListBulletedIcon} />
+        <FooterTabButton text='채팅창' Icon={ChatBubbleOutlineIcon} />
       </ButtonBox>
     </Container>
   );


### PR DESCRIPTION
## 관련 이슈
#8 

## 구현한 내용
- 기존 코드의 부족한 유연함, 재사용성을 보완하기 위하여 컴포넌트 설계를 변경하였습니다.
### 변경한 컴포넌트
- 기존 코드

```tsx
// MatchingListPage
<ButtonBox>
  <FooterTabButton text='매칭 대기 목록' type='list' />
  <FooterTabButton text='채팅창' type='chat' />
</ButtonBox>

interface FooterTabButtonProps {
  type: string;
  text: string;
}

// FooterTabButton
const FooterTabButton = ({ type, text }: FooterTabButtonProps) => {
  return (
    <ButtonBox>
      {type === 'list' ? (
        <FormatListBulletedIcon fontSize='large' />
      ) : (
        <ChatBubbleOutlineIcon fontSize='large' />
      )}
      <SubText>{text}</SubText>
    </ButtonBox>
  );
};

export default FooterTabButton;
```

- 변경한 코드

```tsx
// MatchingListPage
<ButtonBox>
  <FooterTabButton
    text='매칭 대기 목록'
    Icon={FormatListBulletedIcon}
    url='matching'
  />
  <FooterTabButton
    text='채팅창'
    Icon={ChatBubbleOutlineIcon}
    url='chat'
  />
</ButtonBox>

interface FooterTabButtonProps {
  Icon: React.ElementType;
  text: string;
  url: string;
}

// FooterTabButton
const FooterTabButton = ({ text, Icon, url }: FooterTabButtonProps) => {
  return (
    <ButtonBox onClick={handleClick}>
      <Icon fontSize='large' />
      <SubText>{text}</SubText>
    </ButtonBox>
  );
};

export default FooterTabButton;

```
- 저번 pr(#4)에서 컴포넌트가 hook을 두 개 호출하게 되는 '딜레마'에 관하여 이야기 하였습니다.
- 해당 부분의 해결 방법은 간단하게도 'page'를 분리하면 되는 것이었으므로, matching 페이지, chatting 페이지로 각각 분리를 진행하였습니다.

- 추가로 FooterTabButton은 Icon을 prop으로 받아, 외부에서 아이콘을 결정하도록 하였습니다.
- 컴포넌트 내부에서 특정 아이콘에 의존하지 않고, 매번 type이 늘어나지 않도록 해줄 수 있다는 장점 이 있습니다.

### 개선 방안
@geongyu09 
```tsx
interface FooterTabButtonProps {
  Icon: React.ElementType;
  url: string;
  children: React.ReactNode;
}

const FooterTabButton = ({ Icon, url, children }: FooterTabButtonProps) => {
  const navigate = useNavigate();

  const handleClick = () => {
    navigate(`/${url}`);
  };

  return (
    <ButtonBox onClick={handleClick}>
      <Icon fontSize='large' />
      {children}
    </ButtonBox>
  );
};
```
- 위와 같은 형식으로 children을 넘겨주는 방식은 어떤지 궁금합니다!
- 제 생각엔 children으로 무언가를 넘겨주게 된다면, 부모가 자식에 더 많은 '컴포넌트들'을 전달하게 된다면 장점일 수 있겠으나,
단순 text, icon과 같은 몇 개 없는 작은 일들의 경우에는 '굳이...?' 라는 생각이 들어 children을 사용하지 않았는데, 이게 근거가 괜찮은 것인지 궁금합니다.
- 단순한 사용 사례에서는 그냥 props로 전달하는 것이 코드가 더 간결하다고 느꼈습니다.