### PR TITLE
feat: 대기열 등록 버튼 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,8 @@
 import './App.css';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
-// import LoginPage from './pages/LoginPage.tsx';
 import MatchingListPage from './pages/MatchingListPage.tsx';
 import LoginPage from './pages/LoginPage.tsx';
 import ChattingPage from './pages/ChattingPage.tsx';
-import JoinQueueButton from './components/JoinQueueButton.tsx';
 
 function App() {
   return (
@@ -16,9 +14,6 @@ function App() {
           <Route path='/chat' element={<ChattingPage />} />
         </Routes>
       </BrowserRouter>
-
-      <JoinQueueButton />
-
       {/* <LoginPage /> */}
       {/* <MatchingListPage /> */}
     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import MatchingListPage from './pages/MatchingListPage.tsx';
 import LoginPage from './pages/LoginPage.tsx';
 import ChattingPage from './pages/ChattingPage.tsx';
+import JoinQueueButton from './components/JoinQueueButton.tsx';
 
 function App() {
   return (
@@ -15,6 +16,8 @@ function App() {
           <Route path='/chat' element={<ChattingPage />} />
         </Routes>
       </BrowserRouter>
+
+      <JoinQueueButton />
 
       {/* <LoginPage /> */}
       {/* <MatchingListPage /> */}

--- a/src/components/FooterTabButton.tsx
+++ b/src/components/FooterTabButton.tsx
@@ -8,14 +8,15 @@ const ButtonBox = styled(NavLink)`
   align-items: center;
   justify-content: center;
   width: 50%;
-  border: 1px solid black;
   cursor: pointer;
   text-decoration: none;
+  color: black;
 `;
 
 const SubText = styled.p`
-  font-size: 1rem;
+  font-size: 0.75rem;
   font-weight: 400;
+  margin-top: 0.5rem;
 `;
 
 interface FooterTabButtonProps {
@@ -27,7 +28,7 @@ interface FooterTabButtonProps {
 const FooterTabButton = ({ text, Icon, url }: FooterTabButtonProps) => {
   return (
     <ButtonBox to={`/${url}`}>
-      <Icon fontSize='large' />
+      <Icon fontSize='medium' />
       <SubText>{text}</SubText>
     </ButtonBox>
   );

--- a/src/components/JoinQueueButton.tsx
+++ b/src/components/JoinQueueButton.tsx
@@ -4,7 +4,7 @@ const JoinButton = styled.button`
   height: 3.25rem;
   width: 3.25rem;
   border-radius: 50%;
-  border: 1px solid white;
+  border: 3px solid white;
   color: white;
   background-color: #8dcf99;
   cursor: pointer;

--- a/src/components/JoinQueueButton.tsx
+++ b/src/components/JoinQueueButton.tsx
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+
+const JoinButton = styled.button`
+  height: 3.25rem;
+  width: 3.25rem;
+  border-radius: 50%;
+  border: 1px solid white;
+  color: white;
+  background-color: #8dcf99;
+  cursor: pointer;
+`;
+
+const SubText = styled.p`
+  font-size: 2.5rem;
+  font-weight: 500;
+  margin: 0;
+`;
+
+const JoinQueueButton = () => {
+  return (
+    <JoinButton>
+      <SubText>+</SubText>
+    </JoinButton>
+  );
+};
+
+export default JoinQueueButton;

--- a/src/pages/MatchingListPage.tsx
+++ b/src/pages/MatchingListPage.tsx
@@ -3,6 +3,7 @@ import MatchingUser from '../components/MatchingUser.tsx';
 import FooterTabButton from '../components/FooterTabButton.tsx';
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import JoinQueueButton from '../components/JoinQueueButton.tsx';
 
 const Container = styled.div`
   display: flex;
@@ -56,6 +57,14 @@ const ButtonBox = styled.div`
   display: flex;
 `;
 
+const JoinButtonBox = styled.div`
+  position: absolute;
+  bottom: 4rem;
+  left: 50%;
+  transform: translate(-50%, 50%);
+  z-index: 1;
+`;
+
 const MatchingListPage = () => {
   return (
     <Container>
@@ -84,6 +93,10 @@ const MatchingListPage = () => {
         {/* </UserBox> */}
       </Box>
       <ButtonBox>
+        <JoinButtonBox>
+          <JoinQueueButton />
+        </JoinButtonBox>
+
         <FooterTabButton
           text='매칭 대기 목록'
           Icon={FormatListBulletedIcon}

--- a/src/pages/MatchingListPage.tsx
+++ b/src/pages/MatchingListPage.tsx
@@ -15,7 +15,6 @@ const Container = styled.div`
   max-width: 480px;
   margin: 0 auto;
   position: relative;
-  border: 1px solid black;
 `;
 
 const TextBox = styled.div`
@@ -40,8 +39,8 @@ const Box = styled.div`
   overflow-y: auto;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.25rem;
-  border: 1px solid black;
+  gap: 1rem;
+  /* border: 1px solid black; */
 
   &::-webkit-scrollbar {
     display: none;
@@ -51,7 +50,7 @@ const Box = styled.div`
 const ButtonBox = styled.div`
   width: 100%;
   height: 4.5rem;
-  background-color: rgb(243, 237, 247, 100);
+  background-color: #8dcf99;
   position: absolute;
   bottom: 0;
   display: flex;
@@ -73,10 +72,6 @@ const MatchingListPage = () => {
       </TextBox>
       <Box>
         {/* <UserBox> */}
-        <MatchingUser />
-        <MatchingUser />
-        <MatchingUser />
-        <MatchingUser />
         <MatchingUser />
         <MatchingUser />
         <MatchingUser />


### PR DESCRIPTION
## 관련 이슈
#12 

## 구현한 내용
### 설명
- 대기열 등록 버튼을 구현하였습니다
- Figma 디자인 가이드에 맞추어 버튼들에 대한 색상 및 폰트를 수정하였습니다
  - 수정한 버튼은 `FooterTabButton` 입니다. 
### 사진 
![image](https://github.com/user-attachments/assets/5797a28d-5039-4d88-ac77-b31637a70618)
## 리뷰어에게...
### 컴포넌트 분리 관련
- 아래의 FooterTabButton, JoinQueueButton은 이제 한 묶음으로 나누어서 분리하는 방법이 나중에 확인하기 더 편하다고 생각됩니다.
- 특히 Layout이라는 컴포넌트를 만들어서, 해당 부분 하단에 button 묶음 컴포넌트를 추가하면 되겠다는 생각입니다.
- 도식화하면 아래와 같습니다
```
Layout
└── Button Components
    ├── FooterTabButton
    └── JoinQueueButton
```
- 위와 같이 진행하고 Layout 안에 올 것들은 그때그때 아래와 같이 변경해주면 될 것 같다는 생각입니다.
  - MatchingListPage의 경우엔 Button 묶음 컴포넌트 
  - ChattingPage의 경우엔 채팅 입력 Input 컴포넌트
### CSS관련
- 모바일 디자인은 항상 쉽지 않군요... 잘 봐주셔서 감사합니다.
- 혹시 모바일 페이지만 구현해 보신 레포가 있으시다면 추천해주시면 열심히 찾아보겠습니다.
```jsx
const JoinButtonBox = styled.div`
  position: absolute;
  bottom: 4rem;
  left: 50%;
  transform: translate(-50%, 50%);
  z-index: 1;
`;

<ButtonBox>
  <JoinButtonBox>
    <JoinQueueButton />
  </JoinButtonBox>

  <FooterTabButton
    text='매칭 대기 목록'
    Icon={FormatListBulletedIcon}
    url='matching'
  />
  <FooterTabButton
    text='채팅창'
    Icon={ChatBubbleOutlineIcon}
    url='chat'
  />
</ButtonBox>
```
- 위와 같이 항상 styled component 비슷한 css 라이브러리를 사용하며 느끼는 점인데 저런 `JoinButtonBox`는 굳이 필요가 없음에도 항상 추가되는 느낌이 있습니다. 혹여 저런 것이 잘못된 부분인지, 아니면 css in js 라이브러리의 한계인지 궁금합니다.
