### PR TITLE
feat: 채팅 목록 페이지 구현

### DIFF
--- a/src/components/ChattingUser.tsx
+++ b/src/components/ChattingUser.tsx
@@ -1,0 +1,36 @@
+import styled from '@emotion/styled';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+
+const UserBox = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 2.25rem;
+  gap: 0.5rem;
+`;
+
+const TextBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+`;
+
+const SubText = styled.p`
+  font-size: 1rem;
+  font-weight: 400;
+  margin: 0;
+`;
+
+const ChattingUser = () => {
+  return (
+    <UserBox>
+      <AccountCircleIcon fontSize='large' />
+      <TextBox>
+        <SubText>사용자 ID</SubText>
+        <SubText>recent chat message</SubText>
+      </TextBox>
+    </UserBox>
+  );
+};
+
+export default ChattingUser;

--- a/src/pages/ChattingPage.tsx
+++ b/src/pages/ChattingPage.tsx
@@ -1,7 +1,95 @@
-import React from 'react';
+import styled from '@emotion/styled';
+import FooterTabButton from '../components/FooterTabButton.tsx';
+import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import ChattingUser from '../components/ChattingUser.tsx';
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  height: 100vh;
+  max-height: 932px;
+  max-width: 480px;
+  margin: 0 auto;
+  position: relative;
+`;
+
+const TextBox = styled.div`
+  display: flex;
+  width: 80%;
+  align-items: flex-start;
+`;
+
+const MainText = styled.h1`
+  font-size: 1.25rem;
+  font-weight: 500;
+  margin: 0;
+  margin-bottom: 1.5rem;
+`;
+
+const Box = styled.div`
+  box-sizing: border-box;
+  width: 100%;
+  padding: 0 10%;
+  height: 70%;
+  display: flex;
+  overflow-y: auto;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+  /* border: 1px solid black; */
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+const ButtonBox = styled.div`
+  width: 100%;
+  height: 4.5rem;
+  background-color: #8dcf99;
+  position: absolute;
+  bottom: 0;
+  display: flex;
+`;
 
 const ChattingPage = () => {
-  return <div>ChattingPage</div>;
+  return (
+    <Container>
+      <TextBox>
+        <MainText>매칭 대기 목록</MainText>
+      </TextBox>
+      <Box>
+        {/* <UserBox> */}
+        <ChattingUser />
+        <ChattingUser />
+        <ChattingUser />
+        <ChattingUser />
+        <ChattingUser />
+        <ChattingUser />
+        <ChattingUser />
+        <ChattingUser />
+        <ChattingUser />
+        <ChattingUser />
+        <ChattingUser />
+        {/* </UserBox> */}
+      </Box>
+      <ButtonBox>
+        <FooterTabButton
+          text='매칭 대기 목록'
+          Icon={FormatListBulletedIcon}
+          url='matching'
+        />
+        <FooterTabButton
+          text='채팅창'
+          Icon={ChatBubbleOutlineIcon}
+          url='chat'
+        />
+      </ButtonBox>
+    </Container>
+  );
 };
 
 export default ChattingPage;

--- a/src/pages/ChattingPage.tsx
+++ b/src/pages/ChattingPage.tsx
@@ -59,7 +59,7 @@ const ChattingPage = () => {
   return (
     <Container>
       <TextBox>
-        <MainText>매칭 대기 목록</MainText>
+        <MainText>채팅 목록</MainText>
       </TextBox>
       <Box>
         {/* <UserBox> */}


### PR DESCRIPTION
## 관련 이슈
#14 

## 구현한 내용
### 설명
- 채팅 목록 페이지를 구현하였습니다
  - `ChattingPage.tsx`
- 구현한 컴포넌트는 아래와 같습니다
  -  `ChattingUser.tsx`
### 사진 
<img width="366" alt="image" src="https://github.com/user-attachments/assets/22891ad9-1944-4936-a504-01438a4ddd45">

## 리뷰어에게...
### 컴포넌트 분리 관련
- 저번 pr 문서와 이어지는 내용입니다. (#13)
1. 내부 내용 컴포넌트를 생성합니다.
  - 내부의 매칭 대기목록, 채팅 목록 컴포넌트를 생성합니다. (각 `MatchingUserList`, `ChattingUserList`) 
2. `Layout` 컴포넌트를 생성합니다.
  - 해당 `Layout` 컴포넌트를 이용하여 특정 상황별로 (`버튼 클릭 state`를 이용하지 않을까 싶습니다. _더 좋은 방법이 있다면 추천 부탁드립니다._) 삼항 연산자를 사용하여 내부 내용을 관리하는 컴포넌트들(`MatchingUserList`, `ChattingUserList`)을 상황에 맞춰 보여주고, 타 상단 문구, 버튼 유무 또한 `state`에 맞게 렌더링 합니다.
**[좀 더 이해가 쉽도록 그림을 첨부합니다.]**
![IMG_E27C33826871-1](https://github.com/user-attachments/assets/b341f255-097a-4ec8-aefc-67584103f65a)
### 고민점
- 해당 방법중에 첫번째 내부 내용 컴포넌트를 보시면 결국 `MatchingUser`, `ChattingUser`의 **단순 반복**입니다. 그래서 사실 따로 내부 내용 컴포넌트를 만드는 것이 의미가 있을까? 라는 생각을 하긴 하였습니다.
- **하지만**, 결국 저 `MatchingUser`, `ChattingUser`는 **API 호출을 통해서 불러와 지는 것들**이므로, 따로 묶음 컴포넌트를 하나 만들어서 추후 **hook의 분리**를 생각한다면 저런 방식으로 상위 컴포넌트를 하나 생성하는것이 앞으로 유지보수 방면, 코드의 관심사 분리(서버, 클라이언트) 방면에서도 이득이 될 것 같다는 판단에 저런 방향을 생각중인데, 올바른 판단인지 함께 고민해주시면 너무나 감사하겠습니다!