### PR TITLE
feat: 인가 기능 구현

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -51,6 +51,16 @@ const ButtonBox = styled.div`
   margin-top: auto;
 `;
 
+interface LoginResponse {
+  success: boolean;
+  response?: {
+    id: string;
+  };
+  error?: {
+    message: string;
+  };
+}
+
 const LoginPage = () => {
   const navigate = useNavigate();
   const [uid, setUid] = useState('');
@@ -60,7 +70,7 @@ const LoginPage = () => {
 
   const handleLogin = async () => {
     try {
-      const response = await axios.post('/users/login', {
+      const response = await axios.post<LoginResponse>('/users/login', {
         uid,
         password,
       });

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import TextInput from '../components/TextInput.tsx';
 import DefaultButton from '../components/DefaultButton.tsx';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const Container = styled.div`
   display: flex;
@@ -51,6 +52,7 @@ const ButtonBox = styled.div`
 `;
 
 const LoginPage = () => {
+  const navigate = useNavigate();
   const [uid, setUid] = useState('');
   const [password, setPassword] = useState('');
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -64,7 +66,9 @@ const LoginPage = () => {
       });
 
       if (response.data.success) {
-        console.log('로그인 성공', response.data.response);
+        console.log('로그인 성공', response.data.response.id);
+        localStorage.setItem('userNumber', response.data.response.id);
+        navigate('/matching');
       } else {
         setError(response.data.error?.message || '로그인 실패');
       }

--- a/src/pages/MatchingListPage.tsx
+++ b/src/pages/MatchingListPage.tsx
@@ -4,7 +4,6 @@ import FooterTabButton from '../components/FooterTabButton.tsx';
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import JoinQueueButton from '../components/JoinQueueButton.tsx';
-import { useState } from 'react';
 
 const Container = styled.div`
   display: flex;
@@ -41,7 +40,6 @@ const Box = styled.div`
   flex-direction: column;
   align-items: flex-start;
   gap: 1rem;
-  /* border: 1px solid black; */
 
   &::-webkit-scrollbar {
     display: none;
@@ -66,8 +64,6 @@ const JoinButtonBox = styled.div`
 `;
 
 const MatchingListPage = () => {
-  console.log(localStorage.getItem('userNumber'));
-
   return (
     <Container>
       <TextBox>

--- a/src/pages/MatchingListPage.tsx
+++ b/src/pages/MatchingListPage.tsx
@@ -4,6 +4,7 @@ import FooterTabButton from '../components/FooterTabButton.tsx';
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import JoinQueueButton from '../components/JoinQueueButton.tsx';
+import { useState } from 'react';
 
 const Container = styled.div`
   display: flex;
@@ -65,6 +66,8 @@ const JoinButtonBox = styled.div`
 `;
 
 const MatchingListPage = () => {
+  console.log(localStorage.getItem('userNumber'));
+
   return (
     <Container>
       <TextBox>

--- a/src/utils/axios_interceptor.ts
+++ b/src/utils/axios_interceptor.ts
@@ -5,7 +5,7 @@ const api = axios.create({
   timeout: 1000,
 });
 
-axios.interceptors.request.use(
+api.interceptors.request.use(
   (config) => {
     // 요청이 전달되기 전에 작업 수행 -> 여기에 member pk값을 저장하면 될거같다!
     const memberPK = localStorage.getItem('userNumber');

--- a/src/utils/axios_interceptor.tsx
+++ b/src/utils/axios_interceptor.tsx
@@ -1,0 +1,23 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: '',
+  timeout: 1000,
+});
+
+axios.interceptors.request.use(
+  (config) => {
+    // 요청이 전달되기 전에 작업 수행 -> 여기에 member pk값을 저장하면 될거같다!
+    const memberPK = localStorage.getItem('userNumber');
+    if (memberPK) {
+      config.headers['Authorization'] = memberPK;
+    }
+    return config;
+  },
+  (error) => {
+    //요청 오류시 작업 수행
+    return Promise.reject(error);
+  }
+);
+
+export default api;


### PR DESCRIPTION
<!--연관된 티켓 번호를 작성하세요. 예) #111-->
# 🎟️ Related Ticket: #18 

# ✏️ Description
<!--설명을 작성하세요.-->
- BE 개발 속도에 맞추어 login 기능 중 인가(Authorization)을 axios를 사용하여 구현하였습니다.

# 🧩 How
<!-- 구현 방법을 작성하세요.-->
- `axios` 라이브러리를 이용하였습니다.
  - axios의 `interceptor`를 사용하였습니다.
- 플로우는 아래와 같습니다.
  - 로그인 진행
  - pk값을 response로 받아옴
  - 받아온 response 값을 localStorage에 저장
  - 모든 페이지에서 받아온 pk 값을 header에 담아서 be로 전송
- 기존 로그인 기능에 localStorage에 로직을 추가하였습니다. 
  - memberPK값을 저장하는 로직
  - 로그인. 성공시 매칭리스트 페이지로 이동하는 로직
```tsx
const handleLogin = async () => {
    try {
      const response = await axios.post('/users/login', {
        uid,
        password,
      });

      if (response.data.success) {
        console.log('로그인 성공', response.data.response.id);
        localStorage.setItem('userNumber', response.data.response.id);
        navigate('/matching');
      } else {
        setError(response.data.error?.message || '로그인 실패');
      }
    } catch (err) {
      setError('서버 오류 발생, 재시도 바람');
      console.error(err);
    }
  };
```
- axios의 interceptor는 아래와 같이 구현하였습니다
  - **현재 msw사용중이므로 baseURL은 없습니다.**
  - 먼저 `localStorage`에 저장해두었던 `memberPK`값을 가져옵니다.
  - 원래대로라면 Bearer ${token}이 와야 하지만, 현재 memberPK를 이용한 로직을 사용하므로 memberPK 값을 헤더에 설정합니다.
```tsx
import axios from 'axios';

const api = axios.create({
  baseURL: '',
  timeout: 1000,
});

axios.interceptors.request.use(
  (config) => {
    // 요청이 전달되기 전에 작업 수행 -> 여기에 member pk값을 저장하면 될거같다!
    const memberPK = localStorage.getItem('userNumber');
    if (memberPK) {
      config.headers['Authorization'] = memberPK;
    }
    return config;
  },
  (error) => {
    //요청 오류시 작업 수행
    return Promise.reject(error);
  }
);

export default api;
```
# ⚠️ PR 참고 사항
<!-- 참고 사항을 작성하세요.-->
- `utils` 폴더에 `axios_interceptor.tsx` 파일로 분리하였습니다.

# 📸 Screen Shot
<!-- 이미지를 첨부하세요.-->
![image](https://github.com/user-attachments/assets/76052791-bd77-4f23-86f6-9ea02e169115)

# ✅ Todo Check
<!--todo 진행 상황을 체크하세요.-->
- [x] 인가 기능 구현

# 💬 리뷰 요구사항
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.-->
- **보통 `timeout`의 경우에는 어떻게 지정하나요? 기준이 있는지 궁금합니다!**
- 기존 플로우는 아래와 같았습니다.
```
1. 로그인한다
2. pk 값을 받는다
3. localStorage에 해당 pk값을 저장한다
4. 앞으로 모든 페이지에 들어갈 때 pk값을 header에 담아서 be로 전송한다
  - 전송시 useEffect를 사용한다. 
```
- 하지만, @geongyu09 와의 상의에 의해서 useEffect보다 axios의 interceptor가 더 좋다는 의견을 받아들여 전송시 `useEffect`가 아닌 `axios interceptor` 적용으로 변경하였습니다.

**[변경시 장점]**
- 원래 `useEffect`를 사용하여 구현 시
  - 매 페이지마다 useEffect를 통해 localStorage의 값을 불러옵니다.
  - 해당 값을 변수로 저장하여, 해당 변수를 요청을 보낼 때 매번 header에 추가해줍니다.
- axios interceptor사용을 통해 위의 일련의 과정을  axios_interceptor.tsx 파일 하나로 처리할 수 있습니다.
  - **특히 페이지가 더 많아지는 경우**에 위의 간단함이 더욱 장점으로 부각되리라 예상됩니다.
  - 일종의 '모듈화'라고 생각되기도 하네요!

# Etc.
<!--기타-->
참고한 링크들
- https://leeseong010.tistory.com/133
- https://axios-http.com/kr/docs/instance
- https://velog.io/@bokjunwoo/Axios-%EB%AA%A8%EB%93%88%ED%99%94-%EC%9D%B8%ED%84%B0%EC%85%89%ED%84%B0