### PR TITLE
feat: 매칭 대기목록 조회기능 구현

### DIFF
--- a/src/components/MatchingUser.tsx
+++ b/src/components/MatchingUser.tsx
@@ -17,11 +17,15 @@ const SubText = styled.p`
   flex-grow: 1;
 `;
 
-const MatchingUser = () => {
+interface MatchingUserProps {
+  creatorUid: string;
+}
+
+const MatchingUser = ({ creatorUid }: MatchingUserProps) => {
   return (
     <UserBox>
       <AccountCircleIcon fontSize='large' />
-      <SubText>사용자 ID</SubText>
+      <SubText>{creatorUid}</SubText>
       <MatchingButton />
     </UserBox>
   );

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,9 +1,9 @@
-import axios from 'axios';
 import styled from '@emotion/styled';
 import TextInput from '../components/TextInput.tsx';
 import DefaultButton from '../components/DefaultButton.tsx';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import api from '../utils/axios_interceptor.ts';
 
 const Container = styled.div`
   display: flex;
@@ -54,7 +54,7 @@ const ButtonBox = styled.div`
 interface LoginResponse {
   success: boolean;
   response?: {
-    id: string;
+    userPk: string;
   };
   error?: {
     message: string;
@@ -70,14 +70,17 @@ const LoginPage = () => {
 
   const handleLogin = async () => {
     try {
-      const response = await axios.post<LoginResponse>('/users/login', {
+      const response = await api.post<LoginResponse>('/users/login', {
         uid,
         password,
       });
 
       if (response.data.success) {
-        console.log('로그인 성공', response.data.response.id);
-        localStorage.setItem('userNumber', response.data.response.id);
+        console.log('로그인 성공', response.data.response);
+        localStorage.setItem(
+          'userNumber',
+          response.data.response.userPk.toString()
+        );
         navigate('/matching');
       } else {
         setError(response.data.error?.message || '로그인 실패');

--- a/src/pages/MatchingListPage.tsx
+++ b/src/pages/MatchingListPage.tsx
@@ -71,7 +71,7 @@ const MatchingListPage = () => {
   const [wrokSpaces, setWorkSpaces] = useState([]);
 
   useEffect(() => {
-    const fetchData = async () => {
+    const getMatchingList = async () => {
       try {
         const response = await api.get('/workspaces');
         console.log('요청 성공', response.data.response);
@@ -81,7 +81,7 @@ const MatchingListPage = () => {
         console.error(err);
       }
     };
-    fetchData();
+    getMatchingList();
   }, []);
 
   return (

--- a/src/pages/MatchingListPage.tsx
+++ b/src/pages/MatchingListPage.tsx
@@ -69,23 +69,7 @@ const MatchingListPage = () => {
       <TextBox>
         <MainText>매칭 대기 목록</MainText>
       </TextBox>
-      <Box>
-        {/* <UserBox> */}
-        <MatchingUser />
-        <MatchingUser />
-        <MatchingUser />
-        <MatchingUser />
-        <MatchingUser />
-        <MatchingUser />
-        <MatchingUser />
-        <MatchingUser />
-        <MatchingUser />
-        <MatchingUser />
-        <MatchingUser />
-        <MatchingUser />
-        <MatchingUser />
-        {/* </UserBox> */}
-      </Box>
+      <Box></Box>
       <ButtonBox>
         <JoinButtonBox>
           <JoinQueueButton />

--- a/src/pages/MatchingListPage.tsx
+++ b/src/pages/MatchingListPage.tsx
@@ -4,6 +4,8 @@ import FooterTabButton from '../components/FooterTabButton.tsx';
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import JoinQueueButton from '../components/JoinQueueButton.tsx';
+import { useEffect, useState } from 'react';
+import api from '../utils/axios_interceptor.ts';
 
 const Container = styled.div`
   display: flex;
@@ -64,12 +66,37 @@ const JoinButtonBox = styled.div`
 `;
 
 const MatchingListPage = () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [error, setError] = useState('');
+  const [wrokSpaces, setWorkSpaces] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await api.get('/workspaces');
+        console.log('요청 성공', response.data.response);
+        setWorkSpaces(response.data.response);
+      } catch (err) {
+        setError('서버 오류 발생, 재시도 바람');
+        console.error(err);
+      }
+    };
+    fetchData();
+  }, []);
+
   return (
     <Container>
       <TextBox>
         <MainText>매칭 대기 목록</MainText>
       </TextBox>
-      <Box></Box>
+      <Box>
+        {wrokSpaces?.map((workSpace) => (
+          <MatchingUser
+            creatorUid={workSpace.creatorUid}
+            key={workSpace.workspaceId}
+          />
+        ))}
+      </Box>
       <ButtonBox>
         <JoinButtonBox>
           <JoinQueueButton />

--- a/src/utils/axios_interceptor.ts
+++ b/src/utils/axios_interceptor.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: '',
+  baseURL: 'http://15.164.186.158:8080/',
   timeout: 1000,
 });
 

--- a/src/utils/axios_interceptor.ts
+++ b/src/utils/axios_interceptor.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: 'http://15.164.186.158:8080/',
+  baseURL: import.meta.env.VITE_API_BASE_URL,
   timeout: 1000,
 });
 


### PR DESCRIPTION
<!--연관된 티켓 번호를 작성하세요. 예) #111-->
# 🎟️ Related Ticket: #21 

# ✏️ Description
<!--설명을 작성하세요.-->
- 매칭 대기목록(workspaces)조회 기능을 구현하였습니다.

# 🧩 How
<!-- 구현 방법을 작성하세요.-->
- `axios` 라이브러리를 이용하였습니다.
- 로그인 진행(성공) 후 `useEffect`를 통해 최초 `MatchingListPage` 진입시 매칭 대기목록 리스트를 불러옵니다.

# ⚠️ PR 참고 사항
<!-- 참고 사항을 작성하세요.-->
- 기존 `msw`사용에서 `Swagger` 사용으로 변환하였습니다.
- `workSpaces` 상태로 저장하고, 해당 `workSpaces`에 맞게 `MatchingUser`를 불러옵니다.
  - 이 때, 알맞게 `creatorUid`, `key`를 사용합니다. (임의 목데이터를 잠시 넣어서 사용했을 때 데이터 바인딩이 정상적으로 진행되었습니다.)
```tsx
const [error, setError] = useState('');
const [wrokSpaces, setWorkSpaces] = useState([]);

useEffect(() => {
  const getMatchingList = async () => {
    try {
      const response = await api.get('/workspaces');
      console.log('요청 성공', response.data.response);
      setWorkSpaces(response.data.response);
    } catch (err) {
      setError('서버 오류 발생, 재시도 바람');
      console.error(err);
    }
  };
  getMatchingList();
}, []);
```

# 📸 Screen Shot
<!-- 이미지를 첨부하세요.-->
![image](https://github.com/user-attachments/assets/da8696e1-db93-4888-a2a0-214586c66cd6)

# ✅ Todo Check
<!--todo 진행 상황을 체크하세요.-->
- [x] workspace 매칭 대기목록 조회 기능 구현

# 💬 리뷰 요구사항
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.-->
- 현재 모의 데이터가 들어있지 않고 swagger로만 사용중인데, 모의 데이터를 response 형식에 맞게 state(여기선 workSpaces가 되겠군요)에 넣어주고 나서, 직접 데이터 바인딩을 진행하였습니다.
  - 일을 두 번 하게되는 느낌인데, swagger를 통해서 모의 데이터를 몇 개 넣을 수 있는 방법이 존재하나요?(아니면 be측에 요청해야 하나요?) 
- 현재 `try catch문`을 이용중인데, 대부분은 `.then.catch`을 주로 사용중이더라구요. 혹시 어떤 차이가 있나요? 
  - 검색 결과로는 아래와 같았습니다.
    - `try catch`, `.then.catch` **동일한 결과**를 만들어낼 수 있다.
    - 다만, 그러기 위해서 `try catch문` 이용시에는 `async await`을 사용해야 `Promise` 형태가 아닌 동일한 결과로 출력값을 받을 수 있다
  - 이 이외에 뭔가 조금 더 편리하다거나 이런 점들이 있는지, 리뷰어분들은 어떤 방식을 사용하시는지 궁금합니다. 
# Etc.
<!--기타-->
