### PR TITLE
feat: 매칭 생성기능 createMatch 기능 구현

### DIFF
--- a/src/pages/MatchingListPage.tsx
+++ b/src/pages/MatchingListPage.tsx
@@ -68,19 +68,31 @@ const JoinButtonBox = styled.div`
 const MatchingListPage = () => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [error, setError] = useState('');
-  const [wrokSpaces, setWorkSpaces] = useState([]);
+  const [workSpaces, setWorkSpaces] = useState([]);
+
+  const getMatchingList = async () => {
+    try {
+      const response = await api.get('/workspaces');
+      console.log('요청 성공', response.data.response);
+      setWorkSpaces(response.data.response);
+    } catch (err) {
+      setError('서버 오류 발생, 재시도 바람');
+      console.error(err);
+    }
+  };
+
+  const createMatch = async () => {
+    try {
+      const joinResponse = await api.post('/workspace');
+      console.log('매칭 생성 요청 성공', joinResponse.data);
+      getMatchingList();
+    } catch (err) {
+      setError('서버 오류 발생, 재시도 바람');
+      console.error(err);
+    }
+  };
 
   useEffect(() => {
-    const getMatchingList = async () => {
-      try {
-        const response = await api.get('/workspaces');
-        console.log('요청 성공', response.data.response);
-        setWorkSpaces(response.data.response);
-      } catch (err) {
-        setError('서버 오류 발생, 재시도 바람');
-        console.error(err);
-      }
-    };
     getMatchingList();
   }, []);
 
@@ -90,7 +102,7 @@ const MatchingListPage = () => {
         <MainText>매칭 대기 목록</MainText>
       </TextBox>
       <Box>
-        {wrokSpaces?.map((workSpace) => (
+        {workSpaces?.map((workSpace) => (
           <MatchingUser
             creatorUid={workSpace.creatorUid}
             key={workSpace.workspaceId}
@@ -99,7 +111,11 @@ const MatchingListPage = () => {
       </Box>
       <ButtonBox>
         <JoinButtonBox>
-          <JoinQueueButton />
+          <JoinQueueButton
+            onClick={() => {
+              createMatch();
+            }}
+          />
         </JoinButtonBox>
 
         <FooterTabButton


### PR DESCRIPTION
<!--연관된 티켓 번호를 작성하세요. 예) #111-->
# 🎟️ Related Ticket: #22 

# ✏️ Description
<!--설명을 작성하세요.-->
- 매칭(workspace) 생성기능을 구현하였습니다.

# 🧩 How
<!-- 구현 방법을 작성하세요.-->
- `axios` 라이브러리를 이용하였습니다.
- `matchingListPage`에서 하단의 + `joinqueuebutton`을 클릭시에 매칭이 생성됩니다.

# ⚠️ PR 참고 사항
<!-- 참고 사항을 작성하세요.-->
- `post` 요청을 통해서 매칭 생성 요청을 보냅니다.
- 해당 요청 이후 성공시 새로고침 없이 바로 데이터를 받아오기 위해서 `getMatchingList`를 사용하여 `get` 요청을 진행합니다.
```tsx
const getMatchingList = async () => {
  try {
    const response = await api.get('/workspaces');
    console.log('요청 성공', response.data.response);
    setWorkSpaces(response.data.response);
  } catch (err) {
    setError('서버 오류 발생, 재시도 바람');
    console.error(err);
  }
};

const createMatch = async () => {
  try {
    const joinResponse = await api.post('/workspace');
    console.log('매칭 생성 요청 성공', joinResponse.data);
    getMatchingList();
  } catch (err) {
    setError('서버 오류 발생, 재시도 바람');
    console.error(err);
  }
};

useEffect(() => {
  getMatchingList();
}, []);
```

# 📸 Screen Shot
<!-- 이미지를 첨부하세요.-->
![image](https://github.com/user-attachments/assets/83b86024-15ac-4881-b0b9-41c4f8894cb5)

# ✅ Todo Check
<!--todo 진행 상황을 체크하세요.-->
- [x] `workspace` 매칭 생성 기능을 구현합니다.
- [x] 생성된 `workspace`를 `workspaces` 매칭 대기목록 리스트에 추가

# 💬 리뷰 요구사항
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.-->
- 확실히 연동을 많이 안해본 티를 내버렸습니다. (스스로 fe의 역할 be의 역할을 정확하게 분리하지 못하고 있었습니다.)
### 겪었던 문제점
- `swagger`와 `response` 값이 달랐음
- `swagger`의 `response` 값
```JSON
{
  "success": true,
  "response": {},
  "error": {
    "code": "string",
    "message": "string",
    "httpStatus": "100 CONTINUE"
  }
}
```
- 실제 받는 response 값
<img width="325" alt="image" src="https://github.com/user-attachments/assets/e4ea8a90-6936-49ed-aff1-461bac1d8c35">

- `null`값을 받아와서 해당 값을 list에 추가하려고 하니 저런 문제가 발생했던 것!
(나는 처음에 깊은 생각 없이 그냥 be에서 response값이 잘못보내줘서 발생하는 문제라고 생각함)
### 해결 과정
- 사실은 그저 나의 숙련도 미숙이었음
- 나의 플로우
  - 매칭버튼을 클릭하여 매칭 워크스페이스 생성
  - 응답값에서 객체를 받아와 해당 객체를 workSpaces 배열에 추가
- **사실 위의 플로우는 fe와 be 연동과정에서 역할을 혼동했었던 나의 잘못된 플로우**
- 올바른 플로우
  - 매칭버튼을 클릭하여 매칭 워크스페이스 생성
  (이 때 매칭버튼을 클릭하였으므로, post요청으로 be에 특정 유저의 memberPk값이 전달되고 해당 유저가 매칭방을 생성한다는 요청을 보냄)
  - BE에서는 해당 요청을 받고, 기존의 `workspaces list`에 해당 유저의 `workspace`를 추가함
  - FE에서는 `post`응답이 성공일 경우 `update된 list`값을 받아오기 위해 `getMatchingList`를 통해 새로운 `get` 요청!
### 느낀 점
- fe, be의 역할을 정확하게 인지하는 것도 중요하다. 나는 be의 역할을 fe에서 진행하려고 해버렸음!

# Etc.
<!--기타-->
- null값이 들어오더라도 fe단에서 에러를 캐칭해서 유저 경험 측면에서 문제가 생기지 않도록 진행해보는 것도 추가 이슈로 생성하여 해결해 보도록 하겠습니다. 조언 감사합니다! (@loopy-lim )
- **_커밋을 하나만 해놓고 push 후에 pr을 작성해버리고 말았네요... 죄송합니다!_**