### PR TITLE
feat: 채팅방 입장 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ function App() {
           <Route path='/matching' element={<MatchingListPage />} />
           <Route path='/login' element={<LoginPage />} />
           <Route path='/chat' element={<ChattingPage />} />
-          <Route path='/chatroom/:roomNumber' element={<ChatRoomPage />} />
+          <Route path='/chatroom/:chatRoomId' element={<ChatRoomPage />} />
         </Routes>
       </BrowserRouter>
       {/* <LoginPage /> */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ function App() {
           <Route path='/matching' element={<MatchingListPage />} />
           <Route path='/login' element={<LoginPage />} />
           <Route path='/chat' element={<ChattingPage />} />
-          <Route path='/chatroom' element={<ChatRoomPage />} />
+          <Route path='/chatroom/:roomNumber' element={<ChatRoomPage />} />
         </Routes>
       </BrowserRouter>
       {/* <LoginPage /> */}

--- a/src/components/MatchingButton.tsx
+++ b/src/components/MatchingButton.tsx
@@ -14,9 +14,9 @@ const SubText = styled.p`
   margin: 0;
 `;
 
-const MatchingButton = () => {
+const MatchingButton = ({ onClick }) => {
   return (
-    <CircleButton>
+    <CircleButton onClick={onClick}>
       <SubText>매칭</SubText>
     </CircleButton>
   );

--- a/src/components/MatchingUser.tsx
+++ b/src/components/MatchingUser.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import MatchingButton from './MatchingButton.tsx';
+import { useNavigate } from 'react-router-dom';
 
 const UserBox = styled.div`
   display: flex;
@@ -19,14 +20,22 @@ const SubText = styled.p`
 
 interface MatchingUserProps {
   creatorUid: string;
+  roomNumber: number;
 }
 
-const MatchingUser = ({ creatorUid }: MatchingUserProps) => {
+const MatchingUser = ({ creatorUid, roomNumber }: MatchingUserProps) => {
+  const navigate = useNavigate();
+
+  const createChatroom = () => {
+    console.log('채팅방 넘버', roomNumber);
+    navigate(`/chatroom/${roomNumber}`);
+  };
+
   return (
     <UserBox>
       <AccountCircleIcon fontSize='large' />
       <SubText>{creatorUid}</SubText>
-      <MatchingButton />
+      <MatchingButton onClick={createChatroom} />
     </UserBox>
   );
 };

--- a/src/components/MatchingUser.tsx
+++ b/src/components/MatchingUser.tsx
@@ -2,6 +2,9 @@ import styled from '@emotion/styled';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import MatchingButton from './MatchingButton.tsx';
 import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import api from '../utils/axios_interceptor.ts';
+import { useState } from 'react';
 
 const UserBox = styled.div`
   display: flex;
@@ -20,22 +23,36 @@ const SubText = styled.p`
 
 interface MatchingUserProps {
   creatorUid: string;
-  roomNumber: number;
+  workspaceId: number;
 }
 
-const MatchingUser = ({ creatorUid, roomNumber }: MatchingUserProps) => {
+const MatchingUser = ({ creatorUid, workspaceId }: MatchingUserProps) => {
+  const [error, setError] = useState('');
+
   const navigate = useNavigate();
 
-  const createChatroom = () => {
-    console.log('채팅방 넘버', roomNumber);
-    navigate(`/chatroom/${roomNumber}`);
+  // const createChatroom = () => {
+  //   console.log('채팅방 넘버', chatRoomId);
+  //   navigate(`/chatroom/${chatRoomId}`);
+  // };
+
+  const getChatroomId = async () => {
+    try {
+      const response = await api.post(`/participant/${workspaceId}`);
+      console.log('채팅방 아이디 받아오기', response.data.response.chatRoomId);
+      const chatRoomId = response.data.response.chatRoomId;
+      navigate(`/chatroom/${chatRoomId}`);
+    } catch (err) {
+      setError('서버 오류 발생, 재시도 바람');
+      console.error(err);
+    }
   };
 
   return (
     <UserBox>
       <AccountCircleIcon fontSize='large' />
       <SubText>{creatorUid}</SubText>
-      <MatchingButton onClick={createChatroom} />
+      <MatchingButton onClick={getChatroomId} />
     </UserBox>
   );
 };

--- a/src/pages/ChatRoomPage.tsx
+++ b/src/pages/ChatRoomPage.tsx
@@ -75,11 +75,10 @@ const SendButtonBox = styled.div`
   justify-content: center;
 `;
 
-console.log('ChatRoomPage 렌더링됨');
-
 const ChatRoomPage = () => {
-  const { roomNumber } = useParams();
-  console.log('현재 roomNumber:', roomNumber);
+  const { chatRoomId } = useParams();
+  console.log('현재 chatRoomId:', chatRoomId);
+
   return (
     <Container>
       <TextBox>

--- a/src/pages/ChatRoomPage.tsx
+++ b/src/pages/ChatRoomPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import SendIcon from '@mui/icons-material/SendOutlined';
 import OutIcon from '@mui/icons-material/West';
+import { useParams } from 'react-router-dom';
 
 const Container = styled.div`
   display: flex;
@@ -74,7 +75,11 @@ const SendButtonBox = styled.div`
   justify-content: center;
 `;
 
+console.log('ChatRoomPage 렌더링됨');
+
 const ChatRoomPage = () => {
+  const { roomNumber } = useParams();
+  console.log('현재 roomNumber:', roomNumber);
   return (
     <Container>
       <TextBox>

--- a/src/pages/MatchingListPage.tsx
+++ b/src/pages/MatchingListPage.tsx
@@ -106,6 +106,7 @@ const MatchingListPage = () => {
           <MatchingUser
             creatorUid={workSpace.creatorUid}
             key={workSpace.workspaceId}
+            roomNumber={workSpace.workspaceId}
           />
         ))}
       </Box>

--- a/src/pages/MatchingListPage.tsx
+++ b/src/pages/MatchingListPage.tsx
@@ -73,7 +73,7 @@ const MatchingListPage = () => {
   const getMatchingList = async () => {
     try {
       const response = await api.get('/workspaces');
-      console.log('요청 성공', response.data.response);
+      console.log('workspaces 목록 불러오기 성공', response.data.response);
       setWorkSpaces(response.data.response);
     } catch (err) {
       setError('서버 오류 발생, 재시도 바람');
@@ -106,7 +106,7 @@ const MatchingListPage = () => {
           <MatchingUser
             creatorUid={workSpace.creatorUid}
             key={workSpace.workspaceId}
-            roomNumber={workSpace.workspaceId}
+            workspaceId={workSpace.workspaceId}
           />
         ))}
       </Box>


### PR DESCRIPTION
<!--연관된 티켓 번호를 작성하세요. 예) #111-->
# 🎟️ Related Ticket
- #29 

# ✏️ Description
<!--설명을 작성하세요.-->
- 매칭 버튼을 클릭하여 채팅방으로 입장하는 기능을 구현하였습니다.

# 🧩 How
<!-- 구현 방법을 작성하세요.-->
- 기존에 BE에서 제공해주지 않던 chatRoomId를 이제 response값으로 받을 수 있어 구현하였습니다.

- `getChatroomId`
```tsx
const getChatroomId = async () => {
  try {
    const response = await api.post(`/participant/${workspaceId}`);
    console.log('채팅방 아이디 받아오기', response.data.response.chatRoomId);
    const chatRoomId = response.data.response.chatRoomId;
    navigate(`/chatroom/${chatRoomId}`);
  } catch (err) {
    setError('서버 오류 발생, 재시도 바람');
    console.error(err);
  }
};
```
- 매칭하기 버튼을 클릭하면, 해당 매칭의 `workspaceId`를 통해 요청합니다
- 응답값으로 `chatRoomId`를 받환받습니다.
- `chatRoomId`를 이용하여 `navigate(`/chatroom/${chatRoomId}`);` 을 통해서 해당 번호의 채팅방 페이지로 이동합니다.
- 해당 채팅방에서는 `useParams`를 이용하여 `chatRoomId`를 받아옵니다.
  - 해당 `chatRoomId`는 추후 매칭확정 로직에 이용됩니다.

# ⚠️ PR 참고 사항
<!-- 참고 사항을 작성하세요.-->
- 크게 어렵거나 어색한 부분은 없었습니다.

# 📸 Screen Shot
<!-- 이미지를 첨부하세요.-->
![image](https://github.com/user-attachments/assets/45dd94bd-235c-4a89-a389-390e3b7cffa5)
![image](https://github.com/user-attachments/assets/01037c3f-f4ac-49b5-886d-53249ebb1040)

# ✅ Todo Check
<!--todo 진행 상황을 체크하세요.-->
- [x] 채팅방 입장 기능을 구현합니다.

# 💬 리뷰 요구사항
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.-->
- 어렵거나 어색한 부분은 없었지만, 조금 더 간결하게 관리할 필요성이 있다고 느껴집니다!
  - term1 종료 후(소켓 통신을 통한 채팅 등록) react-query적용과 함께 훅 분리까지 진행해 보도록 하겠습니다.
- 추가로 현재 BE측에서 아직 구현이 되지 않은 상태가 있어 매칭 중복 등록, 내가 등록한 매칭도 그대로 입장이 되는 상황입니다. 
  - 이러한 부분의 경우 FE측에서 응답값을 통해 임시로 막아주는 부분이 괜찮을지 조심스레 여쭤봅니다. (상태 관리가 아닌 이러한 직접적인 연산은 어지간하면 BE측에 맡기라는 리뷰를 예전에 받은 적이 있어서, 이런 피치못할 경우엔 어떻게 해야할지 궁금하네요.)
  - 이미 매칭을 등록한 상태면 state로 등록해 매칭카운트가 2가 된다면 그때부터 버튼 클릭시, 요청을 막고 이미 매칭이 존재한다는 모달을 띄워준다던지 하는 부분을 하면 어떨까 생각해 보았습니다.

# Etc.
<!--기타-->
- X
